### PR TITLE
Créer une discussion -> Nouvelle discussion

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -509,7 +509,7 @@ core:
     restore: Restaurer
     settings: Réglages
     sign_up: Inscription
-    start_a_discussion: Démarrer une discussion
+    start_a_discussion: Nouvelle discussion
     some_others: "{count} autre|{count} autres"  # Referenced by flarum-likes.yml, flarum-mentions.yml
     username: Nom d’utilisateur
     write_a_reply: Rédigez une réponse…


### PR DESCRIPTION
Avec l'UI de Flarum, il est facile de comprendre que ce bouton sers à créer un nouveau sujet, cependant la traduction actuelle empêche l'affichage complet du texte, ce qui nous ajoute 3 petits points au lieu d'un bouton propre o/
Par l'image, ça https://i.imgur.com/XqY6MIy.png devient ça https://i.imgur.com/Leg3eZg.png