### PR TITLE
fix(): unread message

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -316,7 +316,7 @@ core:
     post_scrubber:
       now_link: Maintenant
       original_post_link: Message original
-      unread_text: "{count} non lu|{count} non lus"
+      unread_text: "{count} non lus"
       viewing_text: "{index} sur {count} message|{index} sur {count} messages"
 
     # These translations are displayed between posts in the post stream.


### PR DESCRIPTION
Le pluriel n'est plus supporté par flarum.
J'ai mis non lus avec un "s" puisque c'est, il me semble, la situation la plus courante.

https://github.com/flarum/flarum-ext-english/blob/master/locale/core.yml#L319